### PR TITLE
Fix Dvorak support

### DIFF
--- a/yubigo.go
+++ b/yubigo.go
@@ -30,9 +30,9 @@ var (
 	signatureUrlFix = regexp.MustCompile(`\+`)
 )
 
-// Package variable used to override the http client used for communication 
+// Package variable used to override the http client used for communication
 // with Yubico. If nil the standard http.Client will be used - if overriding
-// you need to ensure the transport options are set. 
+// you need to ensure the transport options are set.
 var HTTPClient *http.Client = nil
 
 // Parse and verify the given OTP string into prefix (identity) and ciphertext.
@@ -252,7 +252,7 @@ func (ya *YubiAuth) buildWorkers() {
 }
 
 // Use this method to specify a list of servers for verification.
-// Each server string should contain host + path. 
+// Each server string should contain host + path.
 // Example: "api.yubico.com/wsapi/2.0/verify".
 func (ya *YubiAuth) SetApiServerList(urls ...string) {
 	// Lock

--- a/yubigo.go
+++ b/yubigo.go
@@ -227,8 +227,8 @@ func (ya *YubiAuth) buildWorkers() {
 	for id, apiServer := range ya.apiServerList {
 		// create worker instance with new http.Client instance
 		worker := &verifyWorker{
-			ya: ya,
-			id: id,
+			ya:        ya,
+			id:        id,
 			apiServer: apiServer + "?",
 			work:      make(chan *workRequest),
 			stop:      make(chan bool),

--- a/yubigo.go
+++ b/yubigo.go
@@ -466,12 +466,6 @@ func (ya *YubiAuth) Verify(otp string) (yr *YubiResponse, ok bool, err error) {
 		}
 	}
 
-	// check otp
-	otpCheck, ok := yr.resultParameters["otp"]
-	if !ok || otp != otpCheck {
-		return nil, false, errors.New("Could not validate otp value from server response.")
-	}
-
 	// check nonce
 	nonceCheck, ok := yr.resultParameters["nonce"]
 	if !ok || nonce != nonceCheck {


### PR DESCRIPTION
This removes the check that requires the OTP of the response to match that of the request. The Yubico API does Dvorak to QWERTY conversion which can make this fail. Obviously, this could also be resolved by doing the conversion in the library before hitting the endpoint, but the downside is that we wouldn't get other layout support for free (if Yubico began supporting Colemak, the library would also reject these until proper conversion had been implemented).
